### PR TITLE
Add Docker Quickstart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+################################################
+## run from machine with docker installed
+## requires GNU Make
+################################################
+start-docker: 
+	docker compose run --entrypoint "/bin/bash" --rm demo --login
+
+#####################################################################
+## run from debian machine or container with node (ex: node:18-bullseye)
+######################################################################
+install: install-misc install-gh
+	npm i -g delete-workflow-runs
+
+install-misc:
+	apt update && \
+	apt install -y jq fzf
+
+## see official gh cli install instructions
+## https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+install-gh: 
+	curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+	&& chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+	&& echo "deb [arch=$$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" |  tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& apt update \
+	&& apt install gh -y

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,10 @@
 start-docker: 
 	docker compose run --entrypoint "/bin/bash" --rm demo --login
 
-#####################################################################
-## run from debian machine or container with node (ex: node:18-bullseye)
-######################################################################
+##########################################################
+## run from debian machine or container 
+## requires node/npm (ex: node:18-bullseye container)
+##########################################################
 install: install-misc install-gh
 	npm i -g delete-workflow-runs
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,32 @@ It uses the GitHub API, and requires gh (GitHub CLI) and jq (JSON processor).
 
 5. Press `<enter>` to delete the runs from your GitHub remote.
 
+### Docker Quickstart
+
+1. Start Docker container
+   ```sh
+   $ make start-docker
+   ```
+2. Install `delete-workflow-runs`
+   ```sh
+   $ make install
+   ```
+3. Authenticate to GitHub
+   ```sh
+   $ gh auth login
+   ```
+4. Clone your repository where you wish to delete workflow runs from
+   ```sh
+   $ cd /usr/src
+   $ git clone YOUR_REPO
+   ```
+5. Navigate to the directory of the repository, then run:
+    ```sh
+    $ cd /usr/src/YOUR_REPO
+    $ delete-workflow-runs
+    ```
+
+
 ## Contributing
 I'd love you to contribute to `@jv-k/delete-workflow-runs`, [pull requests](https://github.com/jv-k/delete-workflow-runs/issues/new/choose) are welcome for submitting issues and bugs!
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ It uses the GitHub API, and requires gh (GitHub CLI) and jq (JSON processor).
 
 5. Press `<enter>` to delete the runs from your GitHub remote.
 
-### Docker Quickstart
+## Docker Quickstart
 
 1. Start Docker container
    ```sh
@@ -38,7 +38,7 @@ It uses the GitHub API, and requires gh (GitHub CLI) and jq (JSON processor).
    ```sh
    $ make install
    ```
-3. Authenticate to GitHub (skip if using GH_TOKEN from environment)
+3. Authenticate to GitHub (skip if using `GH_TOKEN` from environment)
    ```sh
    $ gh auth login
    ```

--- a/README.md
+++ b/README.md
@@ -38,20 +38,17 @@ It uses the GitHub API, and requires gh (GitHub CLI) and jq (JSON processor).
    ```sh
    $ make install
    ```
-3. Authenticate to GitHub
+3. Authenticate to GitHub (skip if using GH_TOKEN from environment)
    ```sh
    $ gh auth login
    ```
-4. Clone your repository where you wish to delete workflow runs from
-   ```sh
-   $ cd /usr/src
-   $ git clone YOUR_REPO
-   ```
-5. Navigate to the directory of the repository, then run:
+4. Run the following where REPO_NAME includes your username or org name (ex: `jv-k/delete-workflow-runs`):
     ```sh
-    $ cd /usr/src/YOUR_REPO
-    $ delete-workflow-runs
+    $ delete-workflow-runs REPO_NAME
     ```
+5. Use the `<up>` and `<down>` keys to navigate the list of workflow runs, and select the ones to be deleted with `<tab>`.
+
+6. Press `<enter>` to delete the runs from your GitHub remote.
 
 
 ## Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,5 @@ services:
     volumes:
       - $PWD:/usr/src/delete-gh-workflow-runs
     working_dir: /usr/src/delete-gh-workflow-runs
+    environment:
+      GH_TOKEN: $GH_TOKEN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  demo:
+    image: node:18-bullseye
+    restart: "no"    
+    volumes:
+      - $PWD:/usr/src/delete-gh-workflow-runs
+    working_dir: /usr/src/delete-gh-workflow-runs


### PR DESCRIPTION
This PR adds support to run the `delete-workflows-run` tool from a Docker container.  
This allows a user to run the tool without installing node/npm (or the tool itself) on their machine.

note:
Using the Docker Quickstart option requires [Docker](https://docs.docker.com/get-docker/) to be installed and running.  
Using the Docker Quickstart option (as is) also requires [GNU Make](https://www.gnu.org/software/make/) to be installed.